### PR TITLE
Skip version stage if version is already deployed

### DIFF
--- a/dist/lerna.js
+++ b/dist/lerna.js
@@ -1548,6 +1548,10 @@ var path = __toESM(require("path"));
 var import_find_up = __toESM(require_find_up());
 function version_default(context, _config) {
   return __async(this, null, function* () {
+    if (context.version.old === context.version.new) {
+      context.logger.info("Version in lerna.json is already up to date");
+      return;
+    }
     const packageInfo = yield lernaList(true);
     yield lernaVersion(context.version.new);
     context.changedFiles.push("lerna.json", "package.json");

--- a/dist/npm.js
+++ b/dist/npm.js
@@ -1737,6 +1737,9 @@ function version_default(context, _config) {
     if (context.workspaces != null) {
       context.logger.warn("Cannot run npm version in workspaces");
       return;
+    } else if (context.version.old === context.version.new) {
+      context.logger.info("Version in package.json is already up to date");
+      return;
     }
     yield npmVersion(context.version.new);
     context.changedFiles.push("package.json");

--- a/packages/lerna/CHANGELOG.md
+++ b/packages/lerna/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## `1.0.2`
+
+* Fixed `lerna version` being run when version is already deployed
+
 ## `1.0.0`
 
 * First stable release

--- a/packages/lerna/src/version.ts
+++ b/packages/lerna/src/version.ts
@@ -21,6 +21,11 @@ import { IPluginConfig } from "./config";
 import * as utils from "./utils";
 
 export default async function (context: IContext, _config: IPluginConfig): Promise<void> {
+    if (context.version.old === context.version.new) {
+        context.logger.info("Version in lerna.json is already up to date");
+        return;
+    }
+
     const packageInfo = await utils.lernaList(true);
     await utils.lernaVersion(context.version.new);
     context.changedFiles.push("lerna.json", "package.json");

--- a/packages/npm/CHANGELOG.md
+++ b/packages/npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## `1.0.2`
+
+* Fixed `npm version` being run when version is already deployed
+
 ## `1.0.0`
 
 * Move project .npmrc out of the way for publish

--- a/packages/npm/src/version.ts
+++ b/packages/npm/src/version.ts
@@ -24,6 +24,9 @@ export default async function (context: IContext, _config: IPluginConfig): Promi
     if (context.workspaces != null) {
         context.logger.warn("Cannot run npm version in workspaces");
         return;
+    } else if (context.version.old === context.version.new) {
+        context.logger.info("Version in package.json is already up to date");
+        return;
     }
 
     await utils.npmVersion(context.version.new);


### PR DESCRIPTION
This should prevent unwanted deploys (for example https://github.com/zowe/zowe-cli/pull/1720#issuecomment-1561378765 - thanks @awharn for reporting it)

The new behavior is consistent with our old Jenkins library: https://github.com/zowe/zowe-cli-version-controller/commit/ac72477cff5c64dd8c9bb466797490808ad07b6d